### PR TITLE
Build on multiple GHC versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,16 @@
 language: haskell
-env:
-  - 'UBUNTU_RELEASE=saucy GHCVER=7.8.3'
 
-before_install:
-  - 'sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ ${UBUNTU_RELEASE} main universe"'
-  - 'sudo add-apt-repository -y ppa:hvr/ghc'
-  - 'sudo apt-get update'
-  - 'sudo apt-get install cabal-install-1.20 ghc-$GHCVER happy'
-  - 'export PATH=/opt/ghc/$GHCVER/bin:$PATH'
+ghc:
+  - 7.4
+  - 7.6
+  - 7.8
 
 install:
-  - 'cabal-1.20 update'
-  - 'cabal-1.20 install --only-dependencies --enable-tests --enable-benchmarks'
+  - 'cabal update'
+  - 'cabal install --only-dependencies --enable-tests --enable-benchmarks'
 
 script:
-  - 'cabal-1.20 configure'
-  - 'cabal-1.20 build'
-  - 'cabal-1.20 sdist'
-  - 'cabal-1.20 test'
+  - 'cabal configure'
+  - 'cabal build'
+  - 'cabal sdist'
+  - 'cabal test'

--- a/nagios-check.cabal
+++ b/nagios-check.cabal
@@ -16,7 +16,7 @@ extra-source-files:  README.md
 cabal-version:       >=1.10
 
 source-repository    head
-  type:              git 
+  type:              git
   location:          git@github.com:fractalcat/nagios-check.git
 
 library
@@ -40,7 +40,7 @@ test-suite nagios-check-test
   main-is:           NagiosCheckTest.hs
   type:              exitcode-stdio-1.0
   default-language:    Haskell2010
-  build-depends:       base >=4.7 && <5,
+  build-depends:       base >=4.5 && <5,
                        hspec,
                        QuickCheck,
                        text,


### PR DESCRIPTION
Gets rid of some configuration options that aren't required anymore on Travis, run build on multiple GHC platforms.

Note that the GHC 7.4 build will probably fail until the [constraints on base are loosened in nagios-perfdata](https://github.com/anchor/nagios-perfdata/pull/11).